### PR TITLE
Issue with installing dependencies for line 55 package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "nodetest": "cd test/manual-tests/node/empty-example & start run.cmd",
     "browser": "start test/manual-tests/browser/empty-example/browser.html",
     "doc:show": "start docs/documentation/index.html",
-    "contrib": "npx all-contributors generate",
+    "contrib": "npx all-contributors generate"
   },
   "version": "2.2.9",
   "keywords": [


### PR DESCRIPTION
I think line 55:
"contrib": "npx all-contributors generate", 
<b>should not end with  a comma</b>. Otherwise it generates this issue:

`npm ci
npm ERR! Unexpected token } in JSON at position 1727`